### PR TITLE
Add travis-ci config (odd it was missing as a badge is in the README)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: perl
+perl:
+  - "5.22"
+  - "5.20"
+  - "5.18"
+  - "5.16"
+  - "5.14"
+  - "5.12"
+  - "5.10"
+before_install:
+  - if [ "$TRAVIS_PERL_VERSION" = "5.6.2" ]; then eval $(curl https://travis-perl.github.io/init) --auto; fi


### PR DESCRIPTION
This commit adds travis config, which although there is a badge in the readme, there was not a config in the repo.

Currently 5.10 and 5.12 failing.